### PR TITLE
Reduce bundlesize by using interpolateNumber

### DIFF
--- a/src/RadialGauge.tsx
+++ b/src/RadialGauge.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { arc as d3Arc } from "d3-shape";
-import { interpolate } from "d3-interpolate";
+import { interpolateNumber } from "d3-interpolate";
 import { easeQuadOut } from "d3-ease";
 
 interface SegmentRange {
@@ -257,7 +257,7 @@ export function RadialGauge({
       const progress = Math.min(elapsed / transitionDuration, 1);
       const easedProgress = easingFn(progress);
 
-      const currentValue = interpolate(startValue, value)(easedProgress);
+      const currentValue = interpolateNumber(startValue, value)(easedProgress);
       setTweenValue(currentValue);
 
       if (progress < 1) {


### PR DESCRIPTION
## With `interpolate`

```
➜  react-radial-gauge-component git:(main) ✗ npm run build

> react-radial-gauge-component@0.0.0 build
> tsc -b && vite build

You are using Node.js 20.18.0. Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version.
vite v7.1.3 building for production...
No story files found for the specified pattern: src/**/*.mdx
info Using tsconfig paths for react-docgen
✓ 116 modules transformed.
dist/radial-gauge.js  35.88 kB │ gzip: 11.89 kB
dist/radial-gauge.umd.cjs  25.54 kB │ gzip: 10.60 kB
✓ built in 140ms
```

## With `interpolateNumber`

```
➜  react-radial-gauge-component git:(main) npm run build

> react-radial-gauge-component@0.0.0 build
> tsc -b && vite build

You are using Node.js 20.18.0. Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version.
vite v7.1.3 building for production...
No story files found for the specified pattern: src/**/*.mdx
info Using tsconfig paths for react-docgen
✓ 116 modules transformed.
dist/radial-gauge.js  23.61 kB │ gzip: 7.65 kB
dist/radial-gauge.umd.cjs  16.10 kB │ gzip: 6.67 kB
✓ built in 135ms
```